### PR TITLE
Coordinates in DMS format with postfix hemisphere doesn't work

### DIFF
--- a/src/components/coordinates.ts
+++ b/src/components/coordinates.ts
@@ -189,7 +189,7 @@ export class Coordinates {
             // DMS / D M S H
             {
                 regexp: /^\s*(\d+)\s+(\d+)\s+(\d+\.?\d*)\s*([NEWS])\s*(\d+)\s+(\d+)\s+(\d+\.?\d*)\s*([NEWS])\s*$/,
-                fields: [4, 1, 2, 3, 6, 5, 6, 7],
+                fields: [4, 1, 2, 3, 8, 5, 6, 7],
             },
             // DMS / D M S
             {


### PR DESCRIPTION
This PR fix the problem to parse coordinates in format DMS with postfix hemisphere (see #40).

